### PR TITLE
Fixed issues parsing App Link encoded data and `Request` improvements:

### DIFF
--- a/RouterKit/AppLink.swift
+++ b/RouterKit/AppLink.swift
@@ -13,7 +13,7 @@ import Foundation
  */
 public protocol AppLinkType {
     /// An object containing information from the navigating app.
-    var extras: [String: AnyObject] { get }
+    var extras: [String: String] { get }
 
     /// String containing the URL being navigated to.
     var targetURL: String { get }

--- a/RouterKit/Request.swift
+++ b/RouterKit/Request.swift
@@ -13,7 +13,7 @@ import Foundation
  *  support for potentially multiple URL standards.
  */
 public protocol RequestType {
-    var parameters: [String: AnyObject] { get set }
+    var parameters: [String: String] { get set }
     var path: String { get }
     var scheme: String? { get }
 
@@ -41,63 +41,133 @@ public struct Request: AppLinkType, RequestType {
     static let AppLinkRefererURLKey = "url"
     static let AppLinkRefererAppNameKey = "app_name"
 
-    public var extras: [String: AnyObject]
+    /// Underlying
+    private var requestProperties: [String: AnyObject]
+
+    /// Extras as passed along in the App link request.
+    public var extras: [String: String] {
+        get {
+            return self.requestProperties[Request.AppLinkExtrasKey] as! [String: String]
+        } set {
+            self.requestProperties[Request.AppLinkExtrasKey] = newValue
+        }
+    }
+
+    /// App link request's targetURL
     public let targetURL: String
-    public let refererAppLink: RefererAppLinkType?
-    public let version: String
-    public let userAgent: String?
+
+    /// Referrer of the App link request
+    public var refererAppLink: RefererAppLinkType? {
+        get {
+            if let refererDict = self.requestProperties[Request.AppLinkRefererAppLinkKey] as? [String: String] {
+                let appName = refererDict[Request.AppLinkRefererAppNameKey] ?? ""
+                let url = refererDict[Request.AppLinkRefererURLKey] ?? ""
+                return RefererAppLink(appName: appName, url: url)
+            } else {
+                return nil
+            }
+        }
+    }
+
+    /// App link request spec version. Defaults to 1.0.
+    public var version: String {
+        get {
+            return self.requestProperties[Request.AppLinkVersionKey] as? String ?? "1.0"
+        }
+    }
+
+    /// App link request's user agent.
+    public var userAgent: String? {
+        get {
+            return self.requestProperties[Request.AppLinkUserAgentKey] as? String
+        }
+    }
 
     // MARK: Convenience Properties
-    public var parameters: [String: AnyObject] {
+
+    /// Alias for `extras`.
+    public var parameters: [String: String] {
         get {
             return self.extras
-        }
-        set {
-            self.extras = newValue
+        } set {
+            self.requestProperties[Request.AppLinkExtrasKey] = newValue
         }
     }
+
+    /// Path of the request e.g. example://foo/bar -> /foo/bar, /foo/bar -> /foo/bar
     public var path: String {
         get {
-            return self.targetURL
+            return Request.normalizedPath(self.rawURL)
         }
     }
+
+    /// The scheme of the request. Nil when this is an internal requests within the app i.e. /foo/bar
     public let scheme: String?
 
     public init(url: NSURL) {
         self.rawURL = url
         self.scheme = url.scheme.isEmpty ? nil : Optional(url.scheme)
         self.targetURL = Request.targetURLFromNSURL(url)
-        self.extras = url.query.map(Request.dictionaryFromAppLinkData) ?? [String: AnyObject]()
-        self.userAgent = self.extras[Request.AppLinkUserAgentKey] as? String
-        self.version = self.extras[Request.AppLinkVersionKey] as? String ?? "1.0"
-
-        let refererDict = self.extras[Request.AppLinkRefererAppLinkKey]
-        let refererURL = refererDict?[Request.AppLinkRefererURLKey] as? String
-        let refererAppName = refererDict?[Request.AppLinkRefererAppNameKey] as? String
-        switch (refererAppName, refererURL) {
-        case let (appName?, url?): self.refererAppLink = RefererAppLink(appName: appName, url: url)
-        default: self.refererAppLink = nil
-        }
+        self.requestProperties = url.query.map(Request.normalizedURLParams) ?? [String: AnyObject]()
     }
 
     // url.absoluteString does not behave as you would expect for custom schemes so we need to normalize it
     private static func targetURLFromNSURL(url: NSURL) -> String {
-        let schemePrefix = url.scheme.isEmpty ? "/" : "\(url.scheme)://"
-        // URL parsing in NSURL doesn't handle all combinations of scheme and with or without path.
-        // For our purposes, everything after scheme:// and / for schemeless is considered the path
-        let combinedPath = [url.host ?? "", url.path ?? ""].filter { !$0.isEmpty }.joinWithSeparator("/")
-        return "\(schemePrefix)/\(combinedPath)"
+        let schemeSuffix = url.scheme.isEmpty ? "" : ":/"
+        let combinedPath = self.normalizedPath(url)
+        return "\(url.scheme)\(schemeSuffix)\(combinedPath)"
     }
 
-    // App Link uses url encoded JSON vs. query parameters
-    private static func dictionaryFromAppLinkData(encodedParams: String) -> [String: AnyObject] {
-        let decodedParams = encodedParams.stringByRemovingPercentEncoding
-        let decodedData = decodedParams.flatMap { $0.dataUsingEncoding(NSUTF8StringEncoding) }
-        do {
-            let deserializedParams = try NSJSONSerialization.JSONObjectWithData(decodedData!, options: .AllowFragments) as! [String: AnyObject]
-            return deserializedParams
-        } catch {
-            return [String: AnyObject]()
+    /**
+     Normalized path from the specified URL. This mainly handles different semantics that `NSURL` depending on whether url.scheme is present.
+
+     - parameter url: URL to normalize.
+
+     - returns: Normalized path regardless of whether `url.scheme` is set.
+     */
+    private static func normalizedPath(url: NSURL) -> String {
+        // URL parsing in NSURL doesn't handle all combinations of scheme and with or without path.
+        // For our purposes, everything after scheme:// and / for schemeless is considered the path
+        let normalizedPath = [url.host ?? "", url.path ?? ""].filter { !$0.isEmpty }.joinWithSeparator("/")
+        return "/\(normalizedPath)"
+    }
+
+    private static func normalizedURLParams(encodedQuery: String) -> [String: AnyObject] {
+        typealias GenericKVParamsType = [String: AnyObject]
+        var params = dictionaryFromURLParams(encodedQuery) ?? GenericKVParamsType()
+        var appLinkParams = params.removeValueForKey(AppLinkDataParameterKey) as? GenericKVParamsType ?? GenericKVParamsType()
+        for (k, v) in params {
+            appLinkParams[k] = v
         }
+        return appLinkParams
+    }
+
+    /// App Link uses url encoded JSON vs. query parameters
+    /// encodedParams: foo=bar&baz=qux
+    private static func dictionaryFromURLParams(encodedQuery: String) -> [String: AnyObject] {
+        let encodedParams = encodedQuery.componentsSeparatedByString("&")
+        var resultParamsDictionary = [String: AnyObject]()
+        encodedParams.forEach { kv in
+            let kvPair = kv.componentsSeparatedByString("=")
+            let key = kvPair[0]
+            guard let decodedValue = kvPair[1].stringByRemovingPercentEncoding else {
+                print("Invalid request parameters.")
+                return
+            }
+            let valueIsJSON = decodedValue.hasPrefix("{") && decodedValue.hasSuffix("}")
+            if valueIsJSON {
+                let valueData = decodedValue.dataUsingEncoding(NSUTF8StringEncoding)
+                do {
+                    let deserializedParams = try NSJSONSerialization.JSONObjectWithData(valueData!, options: .AllowFragments) as! [String: AnyObject]
+                    resultParamsDictionary[key] = deserializedParams
+                } catch {
+                    return resultParamsDictionary[key] = [String: AnyObject]()
+                }
+            } else {
+                resultParamsDictionary[key] = decodedValue
+            }
+        }
+
+        return resultParamsDictionary
     }
 }

--- a/RouterKitTests/RequestSpec.swift
+++ b/RouterKitTests/RequestSpec.swift
@@ -13,7 +13,7 @@ import XCTest
 
 class RequestTests: QuickSpec {
     override func spec() {
-        let appLinkWithEncodedData = "example://applinks?al_applink_data=%7B%22user_agent%22%3A%22Bolts%20iOS%201.0.0%22%2C%22target_url%22%3A%22http%3A%5C%2F%5C%2Fexample.com%5C%2Fapplinks%22%2C%22extras%22%3A%7B%22myapp_token%22%3A%22t0kEn%22%7D%7D"
+        let appLinkWithEncodedData = "example://applinks?al_applink_data=%7B%22user_agent%22%3A%22Bolts%20iOS%201.0.0%22%2C%22target_url%22%3A%22example%3A%5C%2F%5C%2Fapplinks%22%2C%22extras%22%3A%7B%22myapp_token%22%3A%22t0kEn%22%7D%2C%22referer_app_link%22%3A%7B%22target_url%22%3A%20%22http%3A%5C%2F%5C%2Fexample.com%5C%2Fdocs%22%2C%22url%22%3A%20%22example%3A%5C%2F%5C%2Fdocs%22%2C%22app_name%22%3A%20%22Example%20App%22%7D%7D"
         let appLinkURL = NSURL(string: appLinkWithEncodedData)!
         let appLinkRequest = Request(url: appLinkURL)
 
@@ -21,6 +21,38 @@ class RequestTests: QuickSpec {
             describe("init") {
                 it("stores the original URL") {
                     expect(appLinkRequest.rawURL).to(equal(appLinkURL))
+                }
+
+                it("returns correct scheme") {
+                    expect(appLinkRequest.scheme).to(equal("example"))
+                }
+
+                it("returns correct targetURL") {
+                    expect(appLinkRequest.targetURL).to(equal("example://applinks"))
+                }
+
+                it("returns correct path") {
+                    expect(appLinkRequest.path).to(equal("/applinks"))
+                }
+
+                it("returns default version if not set") {
+                    expect(appLinkRequest.version).to(equal("1.0"))
+                }
+
+                it("returns version if set") {
+                    let appLinkWithVersion = "example://applinks?al_applink_data=%7B%22user_agent%22%3A%22Bolts%20iOS%201.0.0%22%2C%22target_url%22%3A%22example%3A%5C%2F%5C%2Fapplinks%22%2C%22extras%22%3A%7B%22myapp_token%22%3A%22t0kEn%22%7D%2C%22referer_app_link%22%3A%7B%22target_url%22%3A%20%22http%3A%5C%2F%5C%2Fexample.com%5C%2Fdocs%22%2C%22url%22%3A%20%22example%3A%5C%2F%5C%2Fdocs%22%2C%22app_name%22%3A%20%22Example%20App%22%7D%2C%20%22version%22%3A%20%221.1%22%7D"
+                    let appLinkRequestWithVersion = Request(url: NSURL(string: appLinkWithVersion)!)
+                    expect(appLinkRequestWithVersion.version).to(equal("1.1"))
+                }
+
+                it("returns user agent if set") {
+                    expect(appLinkRequest.userAgent).to(equal(Optional.Some("Bolts iOS 1.0.0")))
+                }
+
+                fit("returns correct referrer app link") {
+                    let refererAppLink = appLinkRequest.refererAppLink
+                    expect(refererAppLink?.appName).to(equal("Example App"))
+                    expect(refererAppLink?.url).to(equal("example://docs"))
                 }
             }
         }


### PR DESCRIPTION
- Issue 1: Encoded params data always failed to be parsed
- Issue 2: Version was 1.0 due to issue #1

Improvements:
- `path` now returns just the path prefixed by `/`
- `scheme` used to return extra `/` e.g. `scheme:///`
